### PR TITLE
fix: fileSaver version bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "xlsx": "^0.11.17",
-    "file-saver": "^1.3.3",
+    "file-saver": "1.3.3",
     "blob.js": "^1.0.1",
     "script-loader": "0.7.2"
   },


### PR DESCRIPTION
固定 file-saver 版本, 修复 file-saver 新版本会导致的找不到 saveAs 函数的 bug.